### PR TITLE
Expose `numprocs` to command line builder

### DIFF
--- a/supervisor/options.py
+++ b/supervisor/options.py
@@ -948,7 +948,7 @@ class ServerOptions(Options):
 
         for process_num in range(numprocs_start, numprocs + numprocs_start):
             expansions = common_expansions
-            expansions.update({'process_num': process_num})
+            expansions.update({'process_num': process_num, 'numprocs': numprocs})
             expansions.update(self.environ_expansions)
 
             environment = dict_of_key_value_pairs(


### PR DESCRIPTION
Expose `numprocs` process setting to command line builder

References: Supervisor/supervisor#1269

Could be easily back-ported to versions up to at least 3.3.4
